### PR TITLE
Use leaderboard entry createdAt instead of updatedAt

### DIFF
--- a/src/pages/LeaderboardEntries.jsx
+++ b/src/pages/LeaderboardEntries.jsx
@@ -122,7 +122,7 @@ const LeaderboardEntries = () => {
                       </div>
                     </TableCell>
                     <TableCell>{entry.score}</TableCell>
-                    <DateCell>{format(new Date(entry.updatedAt), 'dd MMM Y, HH:mm')}</DateCell>
+                    <DateCell>{format(new Date(entry.createdAt), 'dd MMM Y, HH:mm')}</DateCell>
                     <TableCell className='w-40'>
                       <Button
                         variant={entry.hidden ? 'black' : 'grey'}


### PR DESCRIPTION
This makes it easier to see when the actual entry was created/updated, instead of the updatedAt which can change e.g. when the entry is hidden.