### PR TITLE
Fix stale data for player pages and saves

### DIFF
--- a/src/api/useFindPlayer.ts
+++ b/src/api/useFindPlayer.ts
@@ -1,0 +1,31 @@
+import useSWR from 'swr'
+import buildError from '../utils/buildError'
+import { Game } from '../entities/game'
+import { z } from 'zod'
+import { playerSchema } from '../entities/player'
+import makeValidatedGetRequest from './makeValidatedGetRequest'
+
+export default function useFindPlayer(activeGame: Game, playerId?: string) {
+  const fetcher = async ([url, playerId]: [string, string]) => {
+    const qs = new URLSearchParams({
+      search: playerId
+    }).toString()
+
+    const res = await makeValidatedGetRequest(`${url}?${qs}`, z.object({
+      players: z.array(playerSchema)
+    }))
+
+    return res
+  }
+
+  const { data, error } = useSWR(
+    playerId ? [`games/${activeGame.id}/players`, playerId] : null,
+    fetcher
+  )
+
+  return {
+    player: (data?.players ?? []).find((player) => player.id === playerId),
+    loading: !data && !error,
+    error: error && buildError(error)
+  }
+}

--- a/src/api/usePlayerAuthActivities.ts
+++ b/src/api/usePlayerAuthActivities.ts
@@ -7,7 +7,7 @@ import { playerAuthActivitySchema } from '../entities/playerAuthActivity'
 import canPerformAction, { PermissionBasedAction } from '../utils/canPerformAction'
 import { AuthedUser } from '../state/userState'
 
-export default function usePlayerAuthActivities(activeGame: Game, playerId: string, user: AuthedUser) {
+export default function usePlayerAuthActivities(activeGame: Game, user: AuthedUser, playerId?: string) {
   const fetcher = async ([url]: [string]) => {
     const res = await makeValidatedGetRequest(url, z.object({
       activities: z.array(playerAuthActivitySchema)

--- a/src/api/usePlayerLeaderboardEntries.ts
+++ b/src/api/usePlayerLeaderboardEntries.ts
@@ -8,7 +8,7 @@ import makeValidatedGetRequest from './makeValidatedGetRequest'
 import { z } from 'zod'
 import { leaderboardEntrySchema } from '../entities/leaderboardEntry'
 
-export default function usePlayerLeaderboardEntries(activeGame: Game, leaderboards: Leaderboard[], player: Player | null) {
+export default function usePlayerLeaderboardEntries(activeGame: Game, leaderboards: Leaderboard[], player?: Player) {
   const fetcher = async ([activeGame, leaderboards, aliases]: [Game, Leaderboard[], PlayerAlias[]]) => {
     const urls = aliases.flatMap((alias) => {
       return leaderboards.map((leaderboard) => `/games/${activeGame.id}/leaderboards/${leaderboard.id}/entries?aliasId=${alias.id}&page=0`)

--- a/src/pages/PlayerLeaderboardEntries.tsx
+++ b/src/pages/PlayerLeaderboardEntries.tsx
@@ -39,9 +39,7 @@ export default function PlayerLeaderboardEntries() {
   const loading = !player || leaderboardsLoading || entriesLoading
 
   const goToLeaderboard = (internalName: string) => {
-    navigate(routes.leaderboardEntries.replace(':internalName', internalName), {
-      state: { player }
-    })
+    navigate(routes.leaderboardEntries.replace(':internalName', internalName))
   }
 
   const onEntryUpdated = useCallback((entry: LeaderboardEntry) => {

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -59,14 +59,16 @@ export default function PlayerProfile() {
 
   const activeGame = useRecoilValue(activeGameState) as SelectedActiveGame
   const user = useRecoilValue(userState) as AuthedUser
-  const { activities } = usePlayerAuthActivities(activeGame, player?.id, user)
+  const { activities } = usePlayerAuthActivities(activeGame, user, player?.id)
 
   const sections = useDaySections(activities)
 
   const goToPlayerRoute = (route: string) => {
-    navigate(route.replace(':id', player?.id), {
-      state: { player }
-    })
+    if (!player) {
+      throw new Error('Player not found')
+    }
+
+    navigate(route.replace(':id', player.id))
   }
 
   if (!player) {

--- a/src/pages/PlayerProps.tsx
+++ b/src/pages/PlayerProps.tsx
@@ -14,6 +14,10 @@ export default function PlayerProps() {
   const [player] = usePlayer()
 
   const onSave = async (props: Prop[]): Promise<Prop[]> => {
+    if (!player) {
+      throw new Error('Player not found')
+    }
+
     const { player: updatedPlayer } = await updatePlayer(activeGame.id, player.id, { props })
     return updatedPlayer.props
   }

--- a/src/pages/PlayerSaveContent.tsx
+++ b/src/pages/PlayerSaveContent.tsx
@@ -8,12 +8,27 @@ import { Background, BackgroundVariant, Controls, ReactFlow } from '@xyflow/reac
 import SaveDataNode from '../components/saves/SaveDataNode'
 import SaveContentFitManager from '../components/saves/SaveContentFitManager'
 import { GameSave } from '../entities/gameSave'
+import usePlayerSaves from '../api/usePlayerSaves'
+import { useRecoilValue } from 'recoil'
+import activeGameState, { SelectedActiveGame } from '../state/activeGameState'
 
 export default function PlayerSaveContent() {
-  const { id: playerId } = useParams()
+  const { id: playerId, saveId } = useParams()
 
   const location = useLocation()
-  const save: GameSave | undefined = location.state?.save
+  const [save, setSave] = useState<GameSave | undefined>(location.state?.save)
+
+  const activeGame = useRecoilValue(activeGameState) as SelectedActiveGame
+  const { saves } = usePlayerSaves(activeGame, playerId!)
+
+  useEffect(() => {
+    if (saves.length > 0) {
+      const matchingSave = saves.find((s) => s.id === Number(saveId))
+      if (matchingSave) {
+        setSave(matchingSave)
+      }
+    }
+  }, [saves, saveId])
 
   const [isLoading, setLoading] = useState(true)
 

--- a/src/pages/Players.tsx
+++ b/src/pages/Players.tsx
@@ -27,9 +27,7 @@ export default function Players() {
   const navigate = useNavigate()
 
   const goToPlayerProfile = (player: Player) => {
-    navigate(routes.playerProfile.replace(':id', player.id), {
-      state: { player }
-    })
+    navigate(routes.playerProfile.replace(':id', player.id))
   }
 
   return (

--- a/src/pages/__tests__/PlayerProps.test.tsx
+++ b/src/pages/__tests__/PlayerProps.test.tsx
@@ -28,141 +28,11 @@ describe('<PlayerProps />', () => {
 
   const axiosMock = new MockAdapter(api)
 
-  it('should render current props', () => {
-    render(
-      <KitchenSink
-        states={[
-          { node: activeGameState, initialValue: { id: 1 } },
-          { node: userState, initialValue: userValue }
-        ]}
-        routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
-      >
-        <PlayerProps />
-      </KitchenSink>
-    )
-
-    expect(screen.getByText(`Player = ${basePlayer.id}`)).toBeInTheDocument()
-
-    for (const prop of basePlayer.props) {
-      expect(screen.getByText(prop.key)).toBeInTheDocument()
-      expect(screen.getByDisplayValue(prop.value)).toBeInTheDocument()
-    }
+  beforeEach(() => {
+    axiosMock.reset()
   })
 
-  it('should only enable the reset button after a change', async () => {
-    render(
-      <KitchenSink
-        states={[
-          { node: activeGameState, initialValue: { id: 1 } },
-          { node: userState, initialValue: userValue }
-        ]}
-        routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
-      >
-        <PlayerProps />
-      </KitchenSink>
-    )
-
-    expect(screen.getByText('Reset')).toBeDisabled()
-
-    await userEvent.type(screen.getByDisplayValue('80'), '{backspace}4')
-
-    expect(screen.getByDisplayValue('84')).toBeInTheDocument()
-
-    expect(screen.getByText('Reset')).toBeEnabled()
-  })
-
-  it('should only enable the reset a change', async () => {
-    render(
-      <KitchenSink
-        states={[
-          { node: activeGameState, initialValue: { id: 1 } },
-          { node: userState, initialValue: userValue }
-        ]}
-        routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
-      >
-        <PlayerProps />
-      </KitchenSink>
-    )
-
-    expect(screen.getByDisplayValue('80')).toBeInTheDocument()
-    await userEvent.type(screen.getByDisplayValue('80'), '{backspace}4')
-    expect(screen.getByDisplayValue('84')).toBeInTheDocument()
-
-    await userEvent.click(screen.getByText('Reset'))
-    expect(screen.queryByDisplayValue('84')).not.toBeInTheDocument()
-    expect(screen.getByDisplayValue('80')).toBeInTheDocument()
-  })
-
-  it('should delete existing props', async () => {
-    render(
-      <KitchenSink
-        states={[
-          { node: activeGameState, initialValue: { id: 1 } },
-          { node: userState, initialValue: userValue }
-        ]}
-        routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
-      >
-        <PlayerProps />
-      </KitchenSink>
-    )
-
-    expect(screen.getByText('health')).toBeInTheDocument()
-
-    await userEvent.click(screen.getByLabelText('Delete health prop'))
-    expect(screen.queryByText('health')).not.toBeInTheDocument()
-  })
-
-  it('should add new props', async () => {
-    render(
-      <KitchenSink
-        states={[
-          { node: activeGameState, initialValue: { id: 1 } },
-          { node: userState, initialValue: userValue }
-        ]}
-        routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
-      >
-        <PlayerProps />
-      </KitchenSink>
-    )
-
-    await userEvent.click(screen.getByText('New property'))
-
-    await userEvent.type(screen.getByPlaceholderText('Property'), 'treasuresDiscovered')
-    await userEvent.type(screen.getAllByPlaceholderText('Value').at(-1)!, '5')
-
-    expect(screen.getByDisplayValue('treasuresDiscovered')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('5')).toBeInTheDocument()
-  })
-
-  it('should delete new props', async () => {
-    render(
-      <KitchenSink
-        states={[
-          { node: activeGameState, initialValue: { id: 1 } },
-          { node: userState, initialValue: userValue }
-        ]}
-        routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
-      >
-        <PlayerProps />
-      </KitchenSink>
-    )
-
-    await userEvent.click(screen.getByText('New property'))
-
-    await userEvent.type(screen.getByPlaceholderText('Property'), 'treasuresDiscovered')
-
-    await userEvent.click(screen.getByLabelText('Delete treasuresDiscovered prop'))
-
-    expect(screen.queryByDisplayValue('treasuresDiscovered')).not.toBeInTheDocument()
-  })
-
-  it('should load in players that are not in the location state', async () => {
+  it('should render current props', async () => {
     axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
       players: [basePlayer]
     })
@@ -174,7 +44,7 @@ describe('<PlayerProps />', () => {
           { node: userState, initialValue: userValue }
         ]}
         routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}` }]}
+        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
       >
         <PlayerProps />
       </KitchenSink>
@@ -186,6 +56,138 @@ describe('<PlayerProps />', () => {
       expect(screen.getByText(prop.key)).toBeInTheDocument()
       expect(screen.getByDisplayValue(prop.value)).toBeInTheDocument()
     }
+  })
+
+  it('should only enable the reset button after a change', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
+    render(
+      <KitchenSink
+        states={[
+          { node: activeGameState, initialValue: { id: 1 } },
+          { node: userState, initialValue: userValue }
+        ]}
+        routePath='/:id'
+        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
+      >
+        <PlayerProps />
+      </KitchenSink>
+    )
+
+    expect(await screen.findByText('Reset')).toBeDisabled()
+
+    await userEvent.type(screen.getByDisplayValue('80'), '{backspace}4')
+
+    expect(screen.getByDisplayValue('84')).toBeInTheDocument()
+
+    expect(screen.getByText('Reset')).toBeEnabled()
+  })
+
+  it('should only enable the reset a change', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
+    render(
+      <KitchenSink
+        states={[
+          { node: activeGameState, initialValue: { id: 1 } },
+          { node: userState, initialValue: userValue }
+        ]}
+        routePath='/:id'
+        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
+      >
+        <PlayerProps />
+      </KitchenSink>
+    )
+
+    expect(await screen.findByDisplayValue('80')).toBeInTheDocument()
+    await userEvent.type(screen.getByDisplayValue('80'), '{backspace}4')
+    expect(screen.getByDisplayValue('84')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Reset'))
+    expect(screen.queryByDisplayValue('84')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('80')).toBeInTheDocument()
+  })
+
+  it('should delete existing props', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
+    render(
+      <KitchenSink
+        states={[
+          { node: activeGameState, initialValue: { id: 1 } },
+          { node: userState, initialValue: userValue }
+        ]}
+        routePath='/:id'
+        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
+      >
+        <PlayerProps />
+      </KitchenSink>
+    )
+
+    expect(await screen.findByText('health')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText('Delete health prop'))
+    expect(screen.queryByText('health')).not.toBeInTheDocument()
+  })
+
+  it('should add new props', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
+    render(
+      <KitchenSink
+        states={[
+          { node: activeGameState, initialValue: { id: 1 } },
+          { node: userState, initialValue: userValue }
+        ]}
+        routePath='/:id'
+        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
+      >
+        <PlayerProps />
+      </KitchenSink>
+    )
+
+    await userEvent.click(await screen.findByText('New property'))
+
+    await userEvent.type(screen.getByPlaceholderText('Property'), 'treasuresDiscovered')
+    await userEvent.type(screen.getAllByPlaceholderText('Value').at(-1)!, '5')
+
+    expect(screen.getByDisplayValue('treasuresDiscovered')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument()
+  })
+
+  it('should delete new props', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
+    render(
+      <KitchenSink
+        states={[
+          { node: activeGameState, initialValue: { id: 1 } },
+          { node: userState, initialValue: userValue }
+        ]}
+        routePath='/:id'
+        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player: basePlayer } }]}
+      >
+        <PlayerProps />
+      </KitchenSink>
+    )
+
+    await userEvent.click(await screen.findByText('New property'))
+
+    await userEvent.type(screen.getByPlaceholderText('Property'), 'treasuresDiscovered')
+
+    await userEvent.click(screen.getByLabelText('Delete treasuresDiscovered prop'))
+
+    expect(screen.queryByDisplayValue('treasuresDiscovered')).not.toBeInTheDocument()
   })
 
   it('should show a message for players with no props', async () => {
@@ -236,6 +238,10 @@ describe('<PlayerProps />', () => {
   })
 
   it('should save props', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
     axiosMock.onPatch(`http://talo.api/games/1/players/${basePlayer.id}`).replyOnce(200, {
       player: {
         ...basePlayer,
@@ -259,7 +265,7 @@ describe('<PlayerProps />', () => {
       </KitchenSink>
     )
 
-    await userEvent.click(screen.getByText('New property'))
+    await userEvent.click(await screen.findByText('New property'))
 
     await userEvent.type(screen.getByPlaceholderText('Property'), 'treasuresDiscovered')
     await userEvent.type(screen.getAllByPlaceholderText('Value').at(-1)!, '5')
@@ -274,6 +280,10 @@ describe('<PlayerProps />', () => {
   })
 
   it('should render saving errors', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
     axiosMock.onPatch(`http://talo.api/games/1/players/${basePlayer.id}`).networkErrorOnce()
 
     render(
@@ -289,7 +299,7 @@ describe('<PlayerProps />', () => {
       </KitchenSink>
     )
 
-    await userEvent.type(screen.getByDisplayValue('42'), '6')
+    await userEvent.type(await screen.findByDisplayValue('42'), '6')
     await userEvent.click(screen.getByText('Save changes'))
 
     await waitFor(() => {
@@ -297,7 +307,7 @@ describe('<PlayerProps />', () => {
     })
   })
 
-  it('should render meta props', () => {
+  it('should render meta props', async () => {
     const player = {
       ...basePlayer,
       props: [
@@ -308,6 +318,10 @@ describe('<PlayerProps />', () => {
       ]
     }
 
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [player]
+    })
+
     render(
       <KitchenSink
         states={[
@@ -315,13 +329,13 @@ describe('<PlayerProps />', () => {
           { node: userState, initialValue: userValue }
         ]}
         routePath='/:id'
-        initialEntries={[{ pathname: `/${basePlayer.id}`, state: { player } }]}
+        initialEntries={[{ pathname: `/${basePlayer.id}` }]}
       >
         <PlayerProps />
       </KitchenSink>
     )
 
-    expect(screen.getByText('DEV BUILD')).toBeInTheDocument()
+    expect(await screen.findByText('DEV BUILD')).toBeInTheDocument()
     expect(screen.getByText('1')).toBeInTheDocument()
 
     expect(screen.getByText('WINDOW MODE')).toBeInTheDocument()
@@ -332,6 +346,10 @@ describe('<PlayerProps />', () => {
   })
 
   it('should add props from JSON input', async () => {
+    axiosMock.onGet(`http://talo.api/games/1/players?search=${basePlayer.id}`).replyOnce(200, {
+      players: [basePlayer]
+    })
+
     render(
       <KitchenSink
         states={[
@@ -345,7 +363,7 @@ describe('<PlayerProps />', () => {
       </KitchenSink>
     )
 
-    await userEvent.click(screen.getByLabelText('Import props'))
+    await userEvent.click(await screen.findByLabelText('Import props'))
     await userEvent.paste(JSON.stringify({
       speed: '100',
       strength: '50'

--- a/src/utils/usePlayer.ts
+++ b/src/utils/usePlayer.ts
@@ -1,38 +1,29 @@
 import { useEffect, useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
-import findPlayer from '../api/findPlayer'
 import routes from '../constants/routes'
 import activeGameState, { SelectedActiveGame } from '../state/activeGameState'
 import type { Player } from '../entities/player'
+import useFindPlayer from '../api/useFindPlayer'
 
-function usePlayer(): [Player, (player: Player) => void] {
+function usePlayer(): [Player | undefined, (player: Player) => void] {
   const { id } = useParams()
-  const location = useLocation()
 
-  const [player, setPlayer] = useState<Player>(location.state?.player)
   const activeGame = useRecoilValue(activeGameState) as SelectedActiveGame
+  const [player, setPlayer] = useState<Player | undefined>()
+  const { player: fetchedPlayer, loading } = useFindPlayer(activeGame, id)
 
   const navigate = useNavigate()
 
   useEffect(() => {
-    (async () => {
-      if (!player) {
-        try {
-          const { players } = await findPlayer(activeGame.id, id!)
-          const player = players.find((p) => p.id === id)
+    if (loading) return
 
-          if (player) {
-            setPlayer(player)
-          } else {
-            navigate(routes.players, { replace: true })
-          }
-        } catch (err) {
-          navigate(routes.players, { replace: true })
-        }
-      }
-    })()
-  }, [activeGame.id, id, navigate, player])
+    if (fetchedPlayer) {
+      setPlayer(fetchedPlayer)
+    } else {
+      navigate(routes.players, { replace: true })
+    }
+  }, [fetchedPlayer, loading, navigate])
 
   return [player, setPlayer]
 }


### PR DESCRIPTION
Player pages and save content will no longer use the router's `state` object. These pages will now fetch data on load and use that instead.