### PR TITLE
Add billing usage breakdown

### DIFF
--- a/cypress/fixtures/responses/billing/usage.json
+++ b/cypress/fixtures/responses/billing/usage.json
@@ -2,5 +2,10 @@
   "usage": {
     "limit": 2,
     "used": 0
+  },
+  "breakdown": {
+    "live": 0,
+    "dev": 0,
+    "deleted": 0
   }
 }

--- a/src/api/usePricingPlanUsage.ts
+++ b/src/api/usePricingPlanUsage.ts
@@ -1,6 +1,10 @@
 import useSWR from 'swr'
 import { z } from 'zod'
-import { PricingPlanUsage } from '../entities/pricingPlan'
+import {
+  PlayerUsageBreakdown,
+  playerUsageBreakdownSchema,
+  PricingPlanUsage,
+} from '../entities/pricingPlan'
 import buildError from '../utils/buildError'
 import makeValidatedGetRequest from './makeValidatedGetRequest'
 
@@ -13,6 +17,7 @@ export default function usePricingPlanUsage(run: boolean = true) {
           limit: z.number().nullable(),
           used: z.number(),
         }),
+        breakdown: playerUsageBreakdownSchema,
       }),
     )
 
@@ -23,9 +28,11 @@ export default function usePricingPlanUsage(run: boolean = true) {
 
   const limit = data?.usage.limit ?? (typeof data === 'undefined' ? 0 : Infinity)
   const used = data?.usage.used ?? 0
+  const breakdown: PlayerUsageBreakdown = data?.breakdown ?? { live: 0, dev: 0, deleted: 0 }
 
   return {
     usage: { limit, used } satisfies PricingPlanUsage,
+    breakdown,
     loading: !data && !error,
     error: error && buildError(error),
   }

--- a/src/components/billing/BillingUsageTile.tsx
+++ b/src/components/billing/BillingUsageTile.tsx
@@ -1,14 +1,20 @@
+import Tippy from '@tippyjs/react'
 import clsx from 'clsx'
-import { PricingPlanUsage } from '../../entities/pricingPlan'
+import { PlayerUsageBreakdown, PricingPlanUsage } from '../../entities/pricingPlan'
 import ErrorMessage, { TaloError } from '../ErrorMessage'
 import Tile from '../Tile'
 
 type BillingUsageTileProps = {
   usage: PricingPlanUsage
+  breakdown: PlayerUsageBreakdown
   usageError: TaloError | null
 }
 
-export default function BillingUsageTile({ usage, usageError }: BillingUsageTileProps) {
+export default function BillingUsageTile({ usage, breakdown, usageError }: BillingUsageTileProps) {
+  const total = breakdown.live + breakdown.dev + breakdown.deleted
+  const denom = Math.max(usage.limit, total)
+  const pct = (n: number) => (denom ? (n / denom) * 100 : 0)
+
   return (
     <li>
       <Tile
@@ -17,24 +23,54 @@ export default function BillingUsageTile({ usage, usageError }: BillingUsageTile
           <>
             {!usageError && (
               <ul className='w-full space-y-2'>
-                <li className='flex items-center'>
-                  <p className='w-40 shrink-0'>Players</p>
-                  <p
-                    data-testid='players-usage'
-                    className={clsx('w-40 shrink-0 text-right font-mono text-sm font-semibold', {
-                      'text-orange-400': usage.used >= usage.limit,
-                    })}
-                  >
-                    {usage.used.toLocaleString()} / {usage.limit.toLocaleString()}
-                  </p>
-
-                  <div className='relative ml-4 h-3 w-full rounded-sm bg-gray-900'>
-                    <div
-                      className={clsx('absolute h-3 rounded-sm bg-white', {
-                        '!bg-orange-400': usage.used >= usage.limit,
+                <li>
+                  <div className='flex items-center'>
+                    <p className='w-40 shrink-0'>Players</p>
+                    <p
+                      data-testid='players-usage'
+                      className={clsx('w-40 shrink-0 text-right font-mono text-sm font-semibold', {
+                        'text-orange-400': usage.used >= usage.limit,
                       })}
-                      style={{ width: `${Math.min(100, (usage.used / usage.limit) * 100)}%` }}
-                    />
+                    >
+                      {usage.used.toLocaleString()} / {usage.limit.toLocaleString()}
+                    </p>
+                    <Tippy
+                      placement='top'
+                      content={
+                        <div className='flex flex-col space-y-1 p-2'>
+                          <span className='flex items-center'>
+                            <span className='mr-2 inline-block h-2 w-2 rounded-full bg-indigo-400' />
+                            {breakdown.live.toLocaleString()} live
+                          </span>
+                          <span className='flex items-center'>
+                            <span className='mr-2 inline-block h-2 w-2 rounded-full bg-orange-500' />
+                            {breakdown.dev.toLocaleString()} dev
+                          </span>
+                          <span className='flex items-center'>
+                            <span className='mr-2 inline-block h-2 w-2 rounded-full bg-white' />
+                            {breakdown.deleted.toLocaleString()} deleted this month
+                          </span>
+                        </div>
+                      }
+                    >
+                      <div
+                        className='ml-4 flex h-3 w-full overflow-hidden rounded-sm bg-gray-900'
+                        aria-label={`${breakdown.live} live, ${breakdown.dev} dev, ${breakdown.deleted} deleted this month`}
+                      >
+                        <div
+                          className='h-3 bg-indigo-400'
+                          style={{ width: `${pct(breakdown.live)}%` }}
+                        />
+                        <div
+                          className='h-3 bg-orange-500'
+                          style={{ width: `${pct(breakdown.dev)}%` }}
+                        />
+                        <div
+                          className='h-3 bg-white'
+                          style={{ width: `${pct(breakdown.deleted)}%` }}
+                        />
+                      </div>
+                    </Tippy>
                   </div>
                 </li>
               </ul>

--- a/src/components/billing/__tests__/BillingUsageTile.test.tsx
+++ b/src/components/billing/__tests__/BillingUsageTile.test.tsx
@@ -12,6 +12,7 @@ describe('<BillingUsageTile />', () => {
             limit: 5,
             used: 3,
           }}
+          breakdown={{ live: 2, dev: 1, deleted: 0 }}
           usageError={null}
         />
       </KitchenSink>,
@@ -26,6 +27,7 @@ describe('<BillingUsageTile />', () => {
       <KitchenSink>
         <BillingUsageTile
           usage={{ limit: 0, used: 0 }}
+          breakdown={{ live: 0, dev: 0, deleted: 0 }}
           usageError={buildError(new Error('Network Error'))}
         />
       </KitchenSink>,

--- a/src/entities/pricingPlan.ts
+++ b/src/entities/pricingPlan.ts
@@ -15,6 +15,14 @@ export const pricingPlanUsageSchema = z.object({
 
 export type PricingPlanUsage = z.infer<typeof pricingPlanUsageSchema>
 
+export const playerUsageBreakdownSchema = z.object({
+  live: z.number(),
+  dev: z.number(),
+  deleted: z.number(),
+})
+
+export type PlayerUsageBreakdown = z.infer<typeof playerUsageBreakdownSchema>
+
 const pricingPlanProductPriceSchema = z.object({
   currency: z.string(),
   amount: z.number(),

--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -23,7 +23,7 @@ export default function Billing() {
     error: orgPlanError,
   } = useOrganisationPricingPlan()
   const { plans, loading: allPlansLoading, error: allPlansError } = usePricingPlans()
-  const { usage, loading: usageLoading, error: usageError } = usePricingPlanUsage()
+  const { usage, breakdown, loading: usageLoading, error: usageError } = usePricingPlanUsage()
 
   const [yearlyPricing, setYearlyPricing] = useState(false)
 
@@ -86,7 +86,7 @@ export default function Billing() {
               </li>
             )}
 
-            <BillingUsageTile usage={usage} usageError={usageError} />
+            <BillingUsageTile usage={usage} breakdown={breakdown} usageError={usageError} />
 
             {orgPlan?.canViewBillingPortal && <BillingPortalTile />}
           </ul>

--- a/src/pages/__tests__/Billing.test.tsx
+++ b/src/pages/__tests__/Billing.test.tsx
@@ -121,12 +121,18 @@ describe('<Billing />', () => {
     used: 3,
   }
 
+  const breakdown = {
+    live: 2,
+    dev: 1,
+    deleted: 0,
+  }
+
   it('should render the current plan and the other returned plans', async () => {
     axiosMock
       .onGet('http://talo.api/billing/organisation-plan')
       .replyOnce(200, { pricingPlan: orgPlan })
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -144,7 +150,7 @@ describe('<Billing />', () => {
       .onGet('http://talo.api/billing/organisation-plan')
       .replyOnce(200, { pricingPlan: orgPlan })
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -166,7 +172,7 @@ describe('<Billing />', () => {
 
     axiosMock.onGet('http://talo.api/billing/organisation-plan').replyOnce(200, { pricingPlan })
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -185,7 +191,7 @@ describe('<Billing />', () => {
 
     axiosMock.onGet('http://talo.api/billing/organisation-plan').replyOnce(200, { pricingPlan })
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -200,7 +206,7 @@ describe('<Billing />', () => {
   it('should handle organisation plan errors', async () => {
     axiosMock.onGet('http://talo.api/billing/organisation-plan').networkErrorOnce()
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -216,7 +222,7 @@ describe('<Billing />', () => {
       .onGet('http://talo.api/billing/organisation-plan')
       .replyOnce(200, { pricingPlan: orgPlan })
     axiosMock.onGet('http://talo.api/billing/plans').networkErrorOnce()
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -234,7 +240,7 @@ describe('<Billing />', () => {
   it('should handle pricing plan and organisation plan errors', async () => {
     axiosMock.onGet('http://talo.api/billing/organisation-plan').networkErrorOnce()
     axiosMock.onGet('http://talo.api/billing/plans').networkErrorOnce()
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -257,7 +263,7 @@ describe('<Billing />', () => {
 
     axiosMock.onGet('http://talo.api/billing/organisation-plan').replyOnce(200, { pricingPlan })
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -274,7 +280,7 @@ describe('<Billing />', () => {
       .onGet('http://talo.api/billing/organisation-plan')
       .replyOnce(200, { pricingPlan: orgPlan })
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>
@@ -290,7 +296,7 @@ describe('<Billing />', () => {
       .onGet('http://talo.api/billing/organisation-plan')
       .replyOnce(200, { pricingPlan: orgPlan })
     axiosMock.onGet('http://talo.api/billing/plans').replyOnce(200, { pricingPlans })
-    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage })
+    axiosMock.onGet('http://talo.api/billing/usage').replyOnce(200, { usage, breakdown })
 
     render(
       <KitchenSink states={[{ node: userState, initialValue: userValue }]}>


### PR DESCRIPTION
**Breakdown API integration**
- The billing usage endpoint now returns a `breakdown` object with `live`, `dev`, and `deleted` player counts alongside the aggregate `usage` numbers
- A new `playerUsageBreakdownSchema` Zod schema and `PlayerUsageBreakdown` type were added to parse and type this response

**Stacked progress bar**
- The old single-segment progress bar (white fill on dark bg) was replaced with a stacked bar with three color-coded segments: indigo for live, orange for dev, and white for deleted
- The segments scale proportionally based on each category's share of the total (limit or sum, whichever is larger)

**Tooltip breakdown**
- Hovering the progress bar now shows a Tippy popup listing the raw count for each category (`N live`, `N dev`, `N deleted this month`) with matching color dots
- The bar also has an `aria-label` for screen readers