### PR TITLE
Don't block saving props if a blank one was pre-existing

### DIFF
--- a/src/components/PropsEditor.tsx
+++ b/src/components/PropsEditor.tsx
@@ -69,10 +69,8 @@ export default function PropsEditor({ startingProps, onSave, noPropsMessage }: P
   }, [bulkPropsList, newProps.length, originalProps, props])
 
   const enableSaveButton = useMemo(() => {
-    return (
-      newProps.every((prop) => prop.key && prop.value) && props.every((prop) => prop.value !== '')
-    )
-  }, [newProps, props])
+    return newProps.every((prop) => prop.key && prop.value)
+  }, [newProps])
 
   const reset = () => {
     setProps(originalProps)


### PR DESCRIPTION
**Save button validation relaxation**
- Removed the requirement that all existing props must have non-empty values before the save button is enabled
- The save button now only validates that newly added props have a key and value, allowing saves even when existing props have empty values

**Props editing workflow**
- The `enableSaveButton` memo hook no longer depends on the `props` array, only on `newProps`, preventing unnecessary re-computation when existing props change