### PR TITLE
Cap modal height to screen, always render header/footer on top of content

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -10,6 +10,7 @@ type ModalProps = {
   title: string
   hideTitle?: boolean
   children: ReactNode
+  footer?: ReactNode
   modalState: [boolean, (open: boolean) => void]
   scroll?: boolean
   className?: string
@@ -20,6 +21,7 @@ export default function Modal({
   title,
   hideTitle,
   children,
+  footer,
   modalState,
   scroll = true,
   className,
@@ -43,20 +45,16 @@ export default function Modal({
 
   return createPortal(
     <FocusLock>
-      <div className='fixed inset-0 z-50 flex w-screen items-start bg-gray-900/60 text-black transition-colors md:items-center md:p-4'>
+      <div className='fixed inset-0 z-50 flex w-screen items-start overflow-y-auto bg-gray-900/60 text-black transition-colors md:items-center md:p-4'>
         <dialog
           className={clsx(
-            'block h-full w-full bg-white p-0 md:mx-auto md:h-auto md:w-160 md:rounded',
+            'flex h-full w-full flex-col bg-white p-0 md:mx-auto md:h-auto md:max-h-[calc(100vh-2rem)] md:w-160 md:rounded',
             className,
-            {
-              'overflow-y-scroll': scroll,
-              'overflow-y-visible': !scroll,
-            },
           )}
           aria-modal='true'
           aria-labelledby={`modal-${id}-label`}
         >
-          <div className='flex items-center justify-between border-b border-gray-200 p-4'>
+          <div className='flex flex-shrink-0 items-center justify-between border-b border-gray-200 p-4'>
             <h2
               id={`modal-${id}-label`}
               className={clsx('text-xl font-semibold', { hidden: hideTitle })}
@@ -72,7 +70,16 @@ export default function Modal({
             />
           </div>
 
-          {children}
+          <div
+            className={clsx('min-h-0 flex-1', {
+              'overflow-y-auto': scroll,
+              'overflow-y-visible': !scroll,
+            })}
+          >
+            {children}
+          </div>
+
+          {footer && <div className='flex-shrink-0'>{footer}</div>}
         </dialog>
       </div>
     </FocusLock>,

--- a/src/modals/APIKeyDetails.tsx
+++ b/src/modals/APIKeyDetails.tsx
@@ -136,6 +136,47 @@ export default function APIKeyDetails({
       id='api-key-details'
       title={editingKey ? 'Update access key' : 'Create access key'}
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {createdToken ? (
+            <>
+              <div className='w-full md:w-32'>
+                <Button onClick={() => setOpen(false)}>Done</Button>
+              </div>
+              <div className='w-full md:w-32'>
+                <Button
+                  className='w-auto!'
+                  variant='grey'
+                  onClick={async () => {
+                    await navigator.clipboard.writeText(createdToken!)
+                    toast.trigger('Access key copied to clipboard')
+                  }}
+                  icon={<IconCopy />}
+                >
+                  <span>Copy</span>
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className='w-full md:w-32'>
+                <Button
+                  disabled={!user.emailConfirmed || (!editingKey && selectedScopes.length === 0)}
+                  isLoading={isLoading}
+                  onClick={editingKey ? onUpdateClick : onCreateClick}
+                >
+                  {editingKey ? 'Update' : 'Create'}
+                </Button>
+              </div>
+              <div className='w-full md:w-32'>
+                <Button variant='grey' onClick={() => setOpen(false)}>
+                  Close
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      }
     >
       <div>
         {createdToken ? (
@@ -226,46 +267,6 @@ export default function APIKeyDetails({
             {error && <ErrorMessage error={error} />}
           </div>
         )}
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {createdToken ? (
-            <>
-              <div className='w-full md:w-32'>
-                <Button onClick={() => setOpen(false)}>Done</Button>
-              </div>
-              <div className='w-full md:w-32'>
-                <Button
-                  className='w-auto!'
-                  variant='grey'
-                  onClick={async () => {
-                    await navigator.clipboard.writeText(createdToken!)
-                    toast.trigger('Access key copied to clipboard')
-                  }}
-                  icon={<IconCopy />}
-                >
-                  <span>Copy</span>
-                </Button>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className='w-full md:w-32'>
-                <Button
-                  disabled={!user.emailConfirmed || (!editingKey && selectedScopes.length === 0)}
-                  isLoading={isLoading}
-                  onClick={editingKey ? onUpdateClick : onCreateClick}
-                >
-                  {editingKey ? 'Update' : 'Create'}
-                </Button>
-              </div>
-              <div className='w-full md:w-32'>
-                <Button variant='grey' onClick={() => setOpen(false)}>
-                  Close
-                </Button>
-              </div>
-            </>
-          )}
-        </div>
       </div>
     </Modal>
   )

--- a/src/modals/BulkCreateStats.tsx
+++ b/src/modals/BulkCreateStats.tsx
@@ -226,6 +226,35 @@ export function BulkCreateStats({ modalState, mutate }: BulkCreateStatsProps) {
       id='bulk-create-stats'
       title='Bulk import stats'
       modalState={[true, () => goBack(!!results)]}
+      footer={
+        <div
+          className={clsx(
+            'flex flex-col space-y-4 border-t border-gray-300 p-4 md:flex-row-reverse md:justify-between md:space-y-0',
+          )}
+        >
+          <div
+            className={clsx('w-full', {
+              'md:w-44': results,
+              'md:w-32': !results,
+            })}
+          >
+            {results ? (
+              <Button type='button' className='whitespace-nowrap' onClick={onFileUploadClear}>
+                Upload another file
+              </Button>
+            ) : (
+              <Button type='button' disabled={!parsedRows || isLoading} onClick={onImportClick}>
+                Import
+              </Button>
+            )}
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => goBack(!!results)}>
+              {results ? 'Close' : 'Back'}
+            </Button>
+          </div>
+        </div>
+      }
     >
       <div className='space-y-4 p-4'>
         <p>Upload a CSV file to create multiple stats at once.</p>
@@ -366,34 +395,6 @@ export function BulkCreateStats({ modalState, mutate }: BulkCreateStatsProps) {
             </div>
           </div>
         )}
-      </div>
-
-      <div
-        className={clsx(
-          'flex flex-col space-y-4 border-t border-gray-300 p-4 md:flex-row-reverse md:justify-between md:space-y-0',
-        )}
-      >
-        <div
-          className={clsx('w-full', {
-            'md:w-44': results,
-            'md:w-32': !results,
-          })}
-        >
-          {results ? (
-            <Button type='button' className='whitespace-nowrap' onClick={onFileUploadClear}>
-              Upload another file
-            </Button>
-          ) : (
-            <Button type='button' disabled={!parsedRows || isLoading} onClick={onImportClick}>
-              Import
-            </Button>
-          )}
-        </div>
-        <div className='w-full md:w-32'>
-          <Button type='button' variant='grey' onClick={() => goBack(!!results)}>
-            {results ? 'Close' : 'Back'}
-          </Button>
-        </div>
       </div>
     </Modal>
   )

--- a/src/modals/ChannelDetails.tsx
+++ b/src/modals/ChannelDetails.tsx
@@ -180,8 +180,61 @@ export default function ChannelDetails({
       className={clsx('flex flex-col', {
         'md:h-[50vh]!': isMenuOpen,
       })}
+      footer={
+        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!isEditing && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='submit'
+                disabled={!isValid}
+                isLoading={isLoading}
+                extra={{ form: 'channel-details-form' }}
+              >
+                Create
+              </Button>
+            </div>
+          )}
+
+          {isEditing && (
+            <div className='flex space-x-2'>
+              {canPerformAction(user, PermissionBasedAction.DELETE_CHANNEL) && (
+                <div className='w-full md:w-32'>
+                  <Button
+                    type='button'
+                    isLoading={isDeleting}
+                    onClick={onDeleteClick}
+                    variant='red'
+                  >
+                    Delete
+                  </Button>
+                </div>
+              )}
+              <div className='w-full md:w-32'>
+                <Button
+                  type='submit'
+                  disabled={!isValid}
+                  isLoading={isLoading}
+                  extra={{ form: 'channel-details-form' }}
+                >
+                  Update
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      }
     >
-      <form onSubmit={handleSubmit(onSubmit)} className='flex grow flex-col'>
+      <form
+        id='channel-details-form'
+        onSubmit={handleSubmit(onSubmit)}
+        className='flex grow flex-col'
+      >
         <div className='space-y-4 p-4'>
           <TextInput
             id='name'
@@ -284,44 +337,6 @@ export default function ChannelDetails({
           </div>
 
           {apiError && <ErrorMessage error={apiError} />}
-        </div>
-
-        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!isEditing && (
-            <div className='w-full md:w-32'>
-              <Button disabled={!isValid} isLoading={isLoading}>
-                Create
-              </Button>
-            </div>
-          )}
-
-          {isEditing && (
-            <div className='flex space-x-2'>
-              {canPerformAction(user, PermissionBasedAction.DELETE_CHANNEL) && (
-                <div className='w-full md:w-32'>
-                  <Button
-                    type='button'
-                    isLoading={isDeleting}
-                    onClick={onDeleteClick}
-                    variant='red'
-                  >
-                    Delete
-                  </Button>
-                </div>
-              )}
-              <div className='w-full md:w-32'>
-                <Button disabled={!isValid} isLoading={isLoading}>
-                  Update
-                </Button>
-              </div>
-            </div>
-          )}
-
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/ConfirmPlanChange.tsx
+++ b/src/modals/ConfirmPlanChange.tsx
@@ -65,7 +65,32 @@ export default function ConfirmPlanChange({
   })
 
   return (
-    <Modal id='confirm-plan-change' title='Confirm plan change' modalState={modalState}>
+    <Modal
+      id='confirm-plan-change'
+      title='Confirm plan change'
+      modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button
+              variant='green'
+              isLoading={isLoading}
+              onClick={onConfirmClick}
+              extra={{
+                'data-testid': 'confirm-plan-change',
+              }}
+            >
+              Confirm
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      }
+    >
       <form>
         <div className='space-y-4 p-4'>
           <div>
@@ -119,26 +144,6 @@ export default function ConfirmPlanChange({
           </table>
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button
-              variant='green'
-              isLoading={isLoading}
-              onClick={onConfirmClick}
-              extra={{
-                'data-testid': 'confirm-plan-change',
-              }}
-            >
-              Confirm
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/CreateVerificationKey.tsx
+++ b/src/modals/CreateVerificationKey.tsx
@@ -53,7 +53,25 @@ export default function CreateVerificationKey({ modalState, mutate }: CreateVeri
   }, [activeGame.id, version, value, mutate, toast, setOpen])
 
   return (
-    <Modal id='create-verification-key' title='Create verification key' modalState={modalState}>
+    <Modal
+      id='create-verification-key'
+      title='Create verification key'
+      modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button disabled={!version || !value} isLoading={isLoading} onClick={onCreateClick}>
+              Create
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button variant='grey' onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      }
+    >
       <div>
         <div className='space-y-4 p-4'>
           <TextInput
@@ -76,19 +94,6 @@ export default function CreateVerificationKey({ modalState, mutate }: CreateVeri
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button disabled={!version || !value} isLoading={isLoading} onClick={onCreateClick}>
-              Create
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button variant='grey' onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
         </div>
       </div>
     </Modal>

--- a/src/modals/DocsTypeSelection.tsx
+++ b/src/modals/DocsTypeSelection.tsx
@@ -19,6 +19,23 @@ export function DocsTypeSelection({ modalState, onSelected }: Props) {
       title='Choose your Talo integration'
       modalState={modalState}
       className='flex flex-col'
+      footer={
+        <div className='border-t border-gray-200'>
+          <div className='p-4 text-right'>
+            <Button
+              disabled={!selectedType}
+              className='w-auto!'
+              onClick={() => {
+                if (selectedType) {
+                  onSelected(selectedType)
+                }
+              }}
+            >
+              Save selection
+            </Button>
+          </div>
+        </div>
+      }
     >
       <div className='p-4'>
         <RadioGroup
@@ -32,22 +49,6 @@ export function DocsTypeSelection({ modalState, onSelected }: Props) {
           onChange={setSelectedType}
           value={selectedType}
         />
-      </div>
-
-      <div className='border-t border-gray-200'>
-        <div className='p-4 text-right'>
-          <Button
-            disabled={!selectedType}
-            className='w-auto!'
-            onClick={() => {
-              if (selectedType) {
-                onSelected(selectedType)
-              }
-            }}
-          >
-            Save selection
-          </Button>
-        </div>
       </div>
     </Modal>
   )

--- a/src/modals/FeedbackCategoryDetails.tsx
+++ b/src/modals/FeedbackCategoryDetails.tsx
@@ -143,6 +143,37 @@ export default function FeedbackCategoryDetails({
       id='feedback-category-details'
       title={editingCategory ? 'Update feedback category' : 'Create feedback category'}
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!editingCategory && (
+            <div className='w-full md:w-32'>
+              <Button
+                disabled={!internalName || !displayName || !description}
+                isLoading={isLoading}
+                onClick={onCreateClick}
+              >
+                Create
+              </Button>
+            </div>
+          )}
+          {editingCategory && (
+            <div className='w-full md:w-32'>
+              <Button
+                disabled={!internalName || !displayName || !description || isDeleting}
+                isLoading={isLoading}
+                onClick={onUpdateClick}
+              >
+                Update
+              </Button>
+            </div>
+          )}
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      }
     >
       <form>
         <div className='space-y-4 p-4'>
@@ -222,36 +253,6 @@ export default function FeedbackCategoryDetails({
             )}
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!editingCategory && (
-            <div className='w-full md:w-32'>
-              <Button
-                disabled={!internalName || !displayName || !description}
-                isLoading={isLoading}
-                onClick={onCreateClick}
-              >
-                Create
-              </Button>
-            </div>
-          )}
-          {editingCategory && (
-            <div className='w-full md:w-32'>
-              <Button
-                disabled={!internalName || !displayName || !description || isDeleting}
-                isLoading={isLoading}
-                onClick={onUpdateClick}
-              >
-                Update
-              </Button>
-            </div>
-          )}
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/GameCenterIntegrationDetails.tsx
+++ b/src/modals/GameCenterIntegrationDetails.tsx
@@ -150,8 +150,44 @@ export function GameCenterIntegrationDetails({
       id='game-center-integration-details'
       title='Game Center integration'
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!enabled && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='submit'
+                disabled={!isValid}
+                isLoading={isLoading}
+                extra={{ form: 'game-center-integration-form' }}
+              >
+                Enable
+              </Button>
+            </div>
+          )}
+
+          {enabled && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='button'
+                disabled={Boolean(isUpdating)}
+                isLoading={isDeleting}
+                onClick={onDeleteClick}
+                variant='red'
+              >
+                Disable
+              </Button>
+            </div>
+          )}
+
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              {enabled ? 'Done' : 'Cancel'}
+            </Button>
+          </div>
+        </div>
+      }
     >
-      <form onSubmit={handleSubmit(onEnableClick)}>
+      <form id='game-center-integration-form' onSubmit={handleSubmit(onEnableClick)}>
         <div className='space-y-4 p-4'>
           <div>
             To learn more about how the integration works,{' '}
@@ -190,36 +226,6 @@ export function GameCenterIntegrationDetails({
           </div>
 
           {apiError && <ErrorMessage error={apiError} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!enabled && (
-            <div className='w-full md:w-32'>
-              <Button disabled={!isValid} isLoading={isLoading}>
-                Enable
-              </Button>
-            </div>
-          )}
-
-          {enabled && (
-            <div className='w-full md:w-32'>
-              <Button
-                type='button'
-                disabled={Boolean(isUpdating)}
-                isLoading={isDeleting}
-                onClick={onDeleteClick}
-                variant='red'
-              >
-                Disable
-              </Button>
-            </div>
-          )}
-
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              {enabled ? 'Done' : 'Cancel'}
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/GooglePlayGamesIntegrationDetails.tsx
+++ b/src/modals/GooglePlayGamesIntegrationDetails.tsx
@@ -153,8 +153,44 @@ export function GooglePlayGamesIntegrationDetails({
       id='google-play-games-integration-details'
       title='Google Play Games integration'
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!enabled && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='submit'
+                disabled={!isValid}
+                isLoading={isLoading}
+                extra={{ form: 'google-play-games-integration-form' }}
+              >
+                Enable
+              </Button>
+            </div>
+          )}
+
+          {enabled && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='button'
+                disabled={Boolean(isUpdating)}
+                isLoading={isDeleting}
+                onClick={onDeleteClick}
+                variant='red'
+              >
+                Disable
+              </Button>
+            </div>
+          )}
+
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              {enabled ? 'Done' : 'Cancel'}
+            </Button>
+          </div>
+        </div>
+      }
     >
-      <form onSubmit={handleSubmit(onEnableClick)}>
+      <form id='google-play-games-integration-form' onSubmit={handleSubmit(onEnableClick)}>
         <div className='space-y-4 p-4'>
           <div>
             To learn more about how the integration works,{' '}
@@ -220,36 +256,6 @@ export function GooglePlayGamesIntegrationDetails({
           </div>
 
           {apiError && <ErrorMessage error={apiError} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!enabled && (
-            <div className='w-full md:w-32'>
-              <Button disabled={!isValid} isLoading={isLoading}>
-                Enable
-              </Button>
-            </div>
-          )}
-
-          {enabled && (
-            <div className='w-full md:w-32'>
-              <Button
-                type='button'
-                disabled={Boolean(isUpdating)}
-                isLoading={isDeleting}
-                onClick={onDeleteClick}
-                variant='red'
-              >
-                Disable
-              </Button>
-            </div>
-          )}
-
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              {enabled ? 'Done' : 'Cancel'}
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/LeaderboardDetails.tsx
+++ b/src/modals/LeaderboardDetails.tsx
@@ -167,6 +167,37 @@ const LeaderboardDetails = ({
       title={editingLeaderboard ? 'Update leaderboard' : 'Create leaderboard'}
       modalState={modalState}
       className='flex flex-col'
+      footer={
+        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!editingLeaderboard && (
+            <div className='w-full md:w-32'>
+              <Button
+                disabled={!internalName || !displayName || !sortMode}
+                isLoading={isLoading}
+                onClick={onCreateClick}
+              >
+                Create
+              </Button>
+            </div>
+          )}
+          {editingLeaderboard && (
+            <div className='w-full md:w-32'>
+              <Button
+                disabled={!internalName || !displayName || !sortMode || isDeleting}
+                isLoading={isLoading}
+                onClick={onUpdateClick}
+              >
+                Update
+              </Button>
+            </div>
+          )}
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      }
     >
       <form className='flex grow flex-col'>
         <div className='space-y-4 p-4'>
@@ -279,36 +310,6 @@ const LeaderboardDetails = ({
             )}
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!editingLeaderboard && (
-            <div className='w-full md:w-32'>
-              <Button
-                disabled={!internalName || !displayName || !sortMode}
-                isLoading={isLoading}
-                onClick={onCreateClick}
-              >
-                Create
-              </Button>
-            </div>
-          )}
-          {editingLeaderboard && (
-            <div className='w-full md:w-32'>
-              <Button
-                disabled={!internalName || !displayName || !sortMode || isDeleting}
-                isLoading={isLoading}
-                onClick={onUpdateClick}
-              >
-                Update
-              </Button>
-            </div>
-          )}
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/NewGame.tsx
+++ b/src/modals/NewGame.tsx
@@ -52,7 +52,25 @@ export default function NewGame({ modalState }: NewGameProps) {
   }
 
   return (
-    <Modal id='new-game' title='Create new game' modalState={modalState}>
+    <Modal
+      id='new-game'
+      title='Create new game'
+      modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button disabled={!name} isLoading={isLoading} onClick={onCreateClick}>
+              Create
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      }
+    >
       <form>
         <div className='space-y-4 p-4'>
           <TextInput
@@ -66,19 +84,6 @@ export default function NewGame({ modalState }: NewGameProps) {
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button disabled={!name} isLoading={isLoading} onClick={onCreateClick}>
-              Create
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/NewInvite.tsx
+++ b/src/modals/NewInvite.tsx
@@ -88,8 +88,33 @@ export default function NewInvite({ modalState, mutate }: NewInviteProps) {
   }
 
   return (
-    <Modal id='new-invite' title='New invite' modalState={modalState} scroll={false}>
-      <form onSubmit={handleSubmit(onCreateClick)}>
+    <Modal
+      id='new-invite'
+      title='New invite'
+      modalState={modalState}
+      scroll={false}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button
+              type='submit'
+              disabled={!isValid}
+              isLoading={isLoading}
+              extra={{ form: 'new-invite-form' }}
+            >
+              Create
+            </Button>
+          </div>
+
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <form id='new-invite-form' onSubmit={handleSubmit(onCreateClick)}>
         <div className='space-y-4 p-4'>
           <TextInput
             id='email'
@@ -116,20 +141,6 @@ export default function NewInvite({ modalState, mutate }: NewInviteProps) {
           </div>
 
           {apiError && <ErrorMessage error={apiError} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button disabled={!isValid} isLoading={isLoading}>
-              Create
-            </Button>
-          </div>
-
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/RemoveMember.tsx
+++ b/src/modals/RemoveMember.tsx
@@ -55,6 +55,26 @@ export function RemoveMember({ modalState, member, organisationName, mutate }: R
       title={`Remove ${member.username}`}
       modalState={modalState}
       scroll={false}
+      footer={
+        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button
+              type='button'
+              isLoading={isLoading}
+              disabled={confirmText !== 'confirm'}
+              onClick={onRemoveClick}
+              variant='red'
+            >
+              Remove
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={onClose}>
+              Back
+            </Button>
+          </div>
+        </div>
+      }
     >
       <div className='flex grow flex-col'>
         <div className='space-y-4 p-4'>
@@ -73,25 +93,6 @@ export function RemoveMember({ modalState, member, organisationName, mutate }: R
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button
-              type='button'
-              isLoading={isLoading}
-              disabled={confirmText !== 'confirm'}
-              onClick={onRemoveClick}
-              variant='red'
-            >
-              Remove
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={onClose}>
-              Back
-            </Button>
-          </div>
         </div>
       </div>
     </Modal>

--- a/src/modals/ResetFeedbackCategory.tsx
+++ b/src/modals/ResetFeedbackCategory.tsx
@@ -56,6 +56,26 @@ export function ResetFeedbackCategory({ modalState, editingCategory }: ResetFeed
       className={clsx('flex flex-col', {
         'md:h-[55vh]!': isMenuOpen,
       })}
+      footer={
+        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button
+              type='button'
+              isLoading={isLoading}
+              disabled={confirmText !== 'confirm'}
+              onClick={onResetClick}
+              variant='red'
+            >
+              Reset
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => goBack(false)}>
+              Back
+            </Button>
+          </div>
+        </div>
+      }
     >
       <form className='flex grow flex-col'>
         <div className='space-y-4 p-4'>
@@ -88,25 +108,6 @@ export function ResetFeedbackCategory({ modalState, editingCategory }: ResetFeed
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button
-              type='button'
-              isLoading={isLoading}
-              disabled={confirmText !== 'confirm'}
-              onClick={onResetClick}
-              variant='red'
-            >
-              Reset
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => goBack(false)}>
-              Back
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/ResetLeaderboardEntries.tsx
+++ b/src/modals/ResetLeaderboardEntries.tsx
@@ -59,6 +59,26 @@ export function ResetLeaderboardEntries({
       className={clsx('flex flex-col', {
         'md:h-[55vh]!': isMenuOpen,
       })}
+      footer={
+        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button
+              type='button'
+              isLoading={isLoading}
+              disabled={confirmText !== 'confirm'}
+              onClick={onResetClick}
+              variant='red'
+            >
+              Reset
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => goBack(false)}>
+              Back
+            </Button>
+          </div>
+        </div>
+      }
     >
       <form className='flex grow flex-col'>
         <div className='space-y-4 p-4'>
@@ -97,25 +117,6 @@ export function ResetLeaderboardEntries({
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button
-              type='button'
-              isLoading={isLoading}
-              disabled={confirmText !== 'confirm'}
-              onClick={onResetClick}
-              variant='red'
-            >
-              Reset
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => goBack(false)}>
-              Back
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/ResetStat.tsx
+++ b/src/modals/ResetStat.tsx
@@ -56,6 +56,26 @@ export function ResetStat({ modalState, editingStat }: ResetStatProps) {
       className={clsx('flex flex-col', {
         'md:h-[55vh]!': isMenuOpen,
       })}
+      footer={
+        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button
+              type='button'
+              isLoading={isLoading}
+              disabled={confirmText !== 'confirm'}
+              onClick={onResetClick}
+              variant='red'
+            >
+              Reset
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => goBack(false)}>
+              Back
+            </Button>
+          </div>
+        </div>
+      }
     >
       <form className='flex grow flex-col'>
         <div className='space-y-4 p-4'>
@@ -94,25 +114,6 @@ export function ResetStat({ modalState, editingStat }: ResetStatProps) {
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='mt-auto flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button
-              type='button'
-              isLoading={isLoading}
-              disabled={confirmText !== 'confirm'}
-              onClick={onResetClick}
-              variant='red'
-            >
-              Reset
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => goBack(false)}>
-              Back
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/StatDetails.tsx
+++ b/src/modals/StatDetails.tsx
@@ -225,8 +225,51 @@ const StatDetails = ({
       id='stat-details'
       title={editingStat ? 'Update stat' : 'Create stat'}
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!editingStat && (
+            <div className='flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-2'>
+              <div className='w-full md:w-36'>
+                <Button type='button' variant='grey' onClick={onBulkImportClick}>
+                  Bulk import
+                </Button>
+              </div>
+              <div className='w-full md:w-32'>
+                <Button
+                  type='submit'
+                  disabled={!isValid}
+                  isLoading={isLoading}
+                  extra={{ form: 'stat-details-form' }}
+                >
+                  Create
+                </Button>
+              </div>
+            </div>
+          )}
+          {editingStat && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='submit'
+                disabled={!isValid || isDeleting}
+                isLoading={isLoading}
+                extra={{ form: 'stat-details-form' }}
+              >
+                Update
+              </Button>
+            </div>
+          )}
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      }
     >
-      <form onSubmit={handleSubmit(editingStat ? onUpdateClick : onCreateClick)}>
+      <form
+        id='stat-details-form'
+        onSubmit={handleSubmit(editingStat ? onUpdateClick : onCreateClick)}
+      >
         <div className='space-y-4 p-4'>
           <TextInput
             id='internal-name'
@@ -391,35 +434,6 @@ const StatDetails = ({
           )}
 
           {apiError && <ErrorMessage error={apiError} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!editingStat && (
-            <div className='flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-2'>
-              <div className='w-full md:w-36'>
-                <Button type='button' variant='grey' onClick={onBulkImportClick}>
-                  Bulk import
-                </Button>
-              </div>
-              <div className='w-full md:w-32'>
-                <Button disabled={!isValid} isLoading={isLoading}>
-                  Create
-                </Button>
-              </div>
-            </div>
-          )}
-          {editingStat && (
-            <div className='w-full md:w-32'>
-              <Button disabled={!isValid || isDeleting} isLoading={isLoading}>
-                Update
-              </Button>
-            </div>
-          )}
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/SteamworksIntegrationDetails.tsx
+++ b/src/modals/SteamworksIntegrationDetails.tsx
@@ -196,8 +196,44 @@ export function SteamworksIntegrationDetails({
       id='integration-details'
       title={`${upperFirst(editingIntegration?.type)} integration`}
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!enabled && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='submit'
+                disabled={!isValid}
+                isLoading={isLoading}
+                extra={{ form: 'integration-details-form' }}
+              >
+                Enable
+              </Button>
+            </div>
+          )}
+
+          {enabled && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='button'
+                disabled={Boolean(isUpdating)}
+                isLoading={isDeleting}
+                onClick={onDeleteClick}
+                variant='red'
+              >
+                Disable
+              </Button>
+            </div>
+          )}
+
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              {enabled ? 'Done' : 'Cancel'}
+            </Button>
+          </div>
+        </div>
+      }
     >
-      <form onSubmit={handleSubmit(onEnableClick)}>
+      <form id='integration-details-form' onSubmit={handleSubmit(onEnableClick)}>
         <div className='space-y-4 p-4'>
           <div>
             To learn more about how the integration works,{' '}
@@ -311,36 +347,6 @@ export function SteamworksIntegrationDetails({
           </div>
 
           {apiError && <ErrorMessage error={apiError} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!enabled && (
-            <div className='w-full md:w-32'>
-              <Button disabled={!isValid} isLoading={isLoading}>
-                Enable
-              </Button>
-            </div>
-          )}
-
-          {enabled && (
-            <div className='w-full md:w-32'>
-              <Button
-                type='button'
-                disabled={Boolean(isUpdating)}
-                isLoading={isDeleting}
-                onClick={onDeleteClick}
-                variant='red'
-              >
-                Disable
-              </Button>
-            </div>
-          )}
-
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              {enabled ? 'Done' : 'Cancel'}
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/UpdateEntryScore.tsx
+++ b/src/modals/UpdateEntryScore.tsx
@@ -62,6 +62,20 @@ export default function UpdateEntryScore({
       id='update-entry-score'
       title={upperFirst(editingEntry.leaderboardName)}
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button disabled={!score} isLoading={isLoading} onClick={onUpdateClick}>
+              Update
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      }
     >
       <form>
         <div className='space-y-4 p-4'>
@@ -82,19 +96,6 @@ export default function UpdateEntryScore({
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button disabled={!score} isLoading={isLoading} onClick={onUpdateClick}>
-              Update
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/UpdateStatValue.tsx
+++ b/src/modals/UpdateStatValue.tsx
@@ -62,6 +62,20 @@ export default function UpdateStatValue({ modalState, mutate, editingStat }: Upd
       id='update-player-stat'
       title={upperFirst(editingStat.stat.name)}
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          <div className='w-full md:w-32'>
+            <Button disabled={!value} isLoading={isLoading} onClick={onUpdateClick}>
+              Update
+            </Button>
+          </div>
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      }
     >
       <form>
         <div className='space-y-4 p-4'>
@@ -82,19 +96,6 @@ export default function UpdateStatValue({ modalState, mutate, editingStat }: Upd
           />
 
           {error && <ErrorMessage error={error} />}
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          <div className='w-full md:w-32'>
-            <Button disabled={!value} isLoading={isLoading} onClick={onUpdateClick}>
-              Update
-            </Button>
-          </div>
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-          </div>
         </div>
       </form>
     </Modal>

--- a/src/modals/groups/GroupDetails.tsx
+++ b/src/modals/groups/GroupDetails.tsx
@@ -198,8 +198,61 @@ export default function GroupDetails({ modalState, mutate, editingGroup }: Group
       id='group-details'
       title={editingGroup ? 'Update group' : 'Create group'}
       modalState={modalState}
+      footer={
+        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
+          {!editingGroup && (
+            <div className='w-full md:w-32'>
+              <Button
+                type='submit'
+                disabled={!isValid || !allRulesValid}
+                isLoading={isLoading}
+                extra={{ form: 'group-details-form' }}
+              >
+                Create
+              </Button>
+            </div>
+          )}
+
+          {editingGroup && (
+            <div className='flex space-x-2'>
+              {canPerformAction(user, PermissionBasedAction.DELETE_GROUP) && (
+                <div className='w-full md:w-32'>
+                  <Button
+                    type='button'
+                    isLoading={isDeleting}
+                    onClick={onDeleteClick}
+                    variant='red'
+                  >
+                    Delete
+                  </Button>
+                </div>
+              )}
+
+              <div className='w-full md:w-32'>
+                <Button
+                  type='submit'
+                  disabled={!isValid || isDeleting || !allRulesValid}
+                  isLoading={isLoading}
+                  extra={{ form: 'group-details-form' }}
+                >
+                  Update
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className='w-full md:w-32'>
+            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      }
     >
-      <form onSubmit={handleSubmit(editingGroup ? onUpdateClick : onCreateClick)}>
+      <form
+        id='group-details-form'
+        onSubmit={handleSubmit(editingGroup ? onUpdateClick : onCreateClick)}
+      >
         <div className='space-y-4 p-4'>
           <TextInput
             id='name'
@@ -258,45 +311,6 @@ export default function GroupDetails({ modalState, mutate, editingGroup }: Group
             <p>
               {displayableCount} player{displayableCount !== 1 ? 's' : ''} in group
             </p>
-          </div>
-        </div>
-
-        <div className='flex flex-col space-y-4 border-t border-gray-200 p-4 md:flex-row-reverse md:justify-between md:space-y-0'>
-          {!editingGroup && (
-            <div className='w-full md:w-32'>
-              <Button disabled={!isValid || !allRulesValid} isLoading={isLoading}>
-                Create
-              </Button>
-            </div>
-          )}
-
-          {editingGroup && (
-            <div className='flex space-x-2'>
-              {canPerformAction(user, PermissionBasedAction.DELETE_GROUP) && (
-                <div className='w-full md:w-32'>
-                  <Button
-                    type='button'
-                    isLoading={isDeleting}
-                    onClick={onDeleteClick}
-                    variant='red'
-                  >
-                    Delete
-                  </Button>
-                </div>
-              )}
-
-              <div className='w-full md:w-32'>
-                <Button disabled={!isValid || isDeleting || !allRulesValid} isLoading={isLoading}>
-                  Update
-                </Button>
-              </div>
-            </div>
-          )}
-
-          <div className='w-full md:w-32'>
-            <Button type='button' variant='grey' onClick={() => setOpen(false)}>
-              Close
-            </Button>
           </div>
         </div>
       </form>


### PR DESCRIPTION
**Modal layout restructured**
- Modal dialog changed from `h-full` scrollable container to a flex column so only the body area scrolls while header and footer remain fixed
- Added `overflow-y-auto` to the outer wrapper and `max-h` constraint to the dialog to prevent it exceeding viewport height
- The `overflow-y-scroll`/`overflow-y-visible` class was moved from the dialog element to a new scrollable wrapper around `children`

**Footer prop added to Modal component**
- `Modal` gained an optional `footer` prop that renders content below the children in a `flex-shrink-0` container
- This allows footer action bars to be separated from scrollable content rather than being inline at the bottom of the modal body

**Footer content migrated out of modal bodies**
- Action button bars (Create/Update/Delete/Close/Cancel/Done/Copy etc.) were removed from the bottom of every modal's children and passed as the new `footer` prop instead
- Applies to all 16+ affected modals: API keys, channels, leaderboards, stats, groups, integrations, invites, games, and confirmation dialogs

**Form-associated submit buttons**
- Buttons moved into the `footer` prop can no longer live inside a `<form>`, so forms received an `id` attribute and footer buttons use `extra={{ form: '...' }}` to submit from outside the form
- Several buttons that were plain `<Button>` were changed to `<Button type='submit'>` to work with the form id association