### PR TITLE
Fix local date selection and display with DateInput

### DIFF
--- a/src/api/useStats.ts
+++ b/src/api/useStats.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 import { Game } from '../entities/game'
 import { gameStatSchema } from '../entities/gameStat'
 import buildError from '../utils/buildError'
-import { convertDateToUTC } from '../utils/convertDateToUTC'
 import makeValidatedGetRequest from './makeValidatedGetRequest'
 
 export default function useStats(
@@ -15,10 +14,9 @@ export default function useStats(
   const fetcher = async ([url]: [string]) => {
     const qs = new URLSearchParams({
       withMetrics: metricsStartDate || metricsEndDate ? '1' : '0',
-      // the backend prefers the dashboard to send yyyy-mm-dd dates for metrics
-      // so that the start date and end date can be set consistently
-      metricsStartDate: convertDateToUTC(metricsStartDate).split('T')[0],
-      metricsEndDate: convertDateToUTC(metricsEndDate).split('T')[0],
+      // the backend expects yyyy-mm-dd date strings, not full ISO timestamps
+      metricsStartDate: metricsStartDate.split('T')[0],
+      metricsEndDate: metricsEndDate.split('T')[0],
     }).toString()
 
     const res = await makeValidatedGetRequest(

--- a/src/components/DateInput.tsx
+++ b/src/components/DateInput.tsx
@@ -1,7 +1,8 @@
 import Tippy from '@tippyjs/react'
 import { format, isValid } from 'date-fns'
-import { useCallback, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { DayPicker } from 'react-day-picker'
+import { formatLocalDate, parseLocalDate } from '../utils/localDate'
 import TextInput from './TextInput'
 
 type DateInputProps = {
@@ -22,16 +23,13 @@ export default function DateInput({
   const [isOpen, setOpen] = useState(false)
 
   const date = useMemo(() => {
-    return isValid(new Date(value)) ? new Date(value) : new Date()
-  }, [value])
+    if (!value) {
+      return new Date()
+    }
 
-  const getDateStringForValue = useCallback((value: Date): string => {
-    // return YYYY-MM-DD format in local time
-    const year = value.getFullYear()
-    const month = String(value.getMonth() + 1).padStart(2, '0')
-    const day = String(value.getDate()).padStart(2, '0')
-    return `${year}-${month}-${day}`
-  }, [])
+    const parsed = parseLocalDate(value)
+    return isValid(parsed) ? parsed : new Date()
+  }, [value])
 
   return (
     <div>
@@ -48,7 +46,7 @@ export default function DateInput({
             onSelect={(selectedDate) => {
               const newDate = selectedDate ?? new Date()
               onDateChange?.(newDate)
-              onDateTimeStringChange?.(getDateStringForValue(newDate))
+              onDateTimeStringChange?.(formatLocalDate(newDate))
 
               setOpen(false)
             }}

--- a/src/components/__tests__/DateInput.tz.test.tsx
+++ b/src/components/__tests__/DateInput.tz.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import DateInput from '../DateInput'
+
+// Runs under TZ=America/Los_Angeles (see vite.config.ts). The bug was that
+// `new Date('2026-07-10')` parses as UTC midnight = 5pm the previous day
+// local, so the input showed the wrong day in non-UTC zones.
+describe('<DateInput /> (tz)', () => {
+  it('should render date-only strings in the local timezone', () => {
+    render(<DateInput id='test' value='2026-07-10' />)
+
+    expect(screen.getByDisplayValue('10 Jul 2026')).toBeInTheDocument()
+  })
+})

--- a/src/components/events/EventsFilter.tsx
+++ b/src/components/events/EventsFilter.tsx
@@ -43,7 +43,7 @@ export function EventsFilter({
   }, [eventNames, eventNamefilter])
 
   return (
-    <div>
+    <div className='self-end'>
       <Tippy
         placement='bottom-start'
         offset={[0, 8]}

--- a/src/components/events/EventsFiltersSection.tsx
+++ b/src/components/events/EventsFiltersSection.tsx
@@ -42,7 +42,7 @@ export default function EventsFiltersSection({ eventNames, error, entityName = '
         />
       </div>
 
-      <div className='flex w-full items-end space-x-4 md:w-1/2'>
+      <div className='flex w-full items-start space-x-4 md:w-1/2'>
         <div className='w-1/3'>
           <DateInput
             id='start-date'

--- a/src/pages/LeaderboardEntries.tsx
+++ b/src/pages/LeaderboardEntries.tsx
@@ -201,7 +201,7 @@ export default function LeaderboardEntries() {
           />
         </div>
 
-        <div className='flex w-full items-end space-x-4 md:w-1/2'>
+        <div className='flex w-full items-start space-x-4 md:w-1/2'>
           <div className='w-1/3'>
             <DateInput
               id='start-date'

--- a/src/pages/StatMetrics.tsx
+++ b/src/pages/StatMetrics.tsx
@@ -80,7 +80,7 @@ export default function StatMetrics() {
           />
         </div>
 
-        <div className='flex w-full items-end space-x-4 md:w-1/2'>
+        <div className='flex w-full items-start space-x-4 md:w-1/2'>
           <div className='w-1/3'>
             <DateInput
               id='start-date'

--- a/src/utils/__tests__/convertDateToUTC.test.ts
+++ b/src/utils/__tests__/convertDateToUTC.test.ts
@@ -6,23 +6,25 @@ describe('convertDateToUTC', () => {
     expect(convertDateToUTC('')).toBe('')
   })
 
-  it('should return UTC start of day for a date string', () => {
-    expect(convertDateToUTC('2026-02-23')).toBe('2026-02-23T00:00:00.000Z')
+  // Local date strings come from date-fns `format()` and the date inputs, both
+  // in the user's local timezone, so the UTC range must span that local day.
+  // LA is PST (UTC-8) in February.
+  it('should return the UTC instant of local start of day for a date string', () => {
+    expect(convertDateToUTC('2026-02-23')).toBe('2026-02-23T08:00:00.000Z')
   })
 
-  it('should return UTC end of day when endOfDay is true', () => {
-    expect(convertDateToUTC('2026-02-23', true)).toBe('2026-02-23T23:59:59.999Z')
+  it('should return the UTC instant of local end of day when endOfDay is true', () => {
+    expect(convertDateToUTC('2026-02-23', true)).toBe('2026-02-24T07:59:59.999Z')
   })
 
   it('should handle a date string with a time component', () => {
-    expect(convertDateToUTC('2026-02-23T15:30:00')).toBe('2026-02-23T00:00:00.000Z')
+    expect(convertDateToUTC('2026-02-23T15:30:00')).toBe('2026-02-23T08:00:00.000Z')
   })
 
-  // Simulates a UTC-8 user picking the 7d filter: useTimePeriod produces local
-  // calendar date strings ("2021-06-05", "2021-06-12") which convertDateToUTC
-  // must treat as UTC day boundaries, not local time shifted by the offset.
-  it('should produce UTC day boundaries from date strings regardless of local timezone', () => {
-    expect(convertDateToUTC('2021-06-05')).toBe('2021-06-05T00:00:00.000Z')
-    expect(convertDateToUTC('2021-06-12', true)).toBe('2021-06-12T23:59:59.999Z')
+  // LA is PDT (UTC-7) in June. The point of this test: the UTC range must
+  // match the user's local day, not a shifted UTC day.
+  it('should produce local-day UTC boundaries across DST offsets', () => {
+    expect(convertDateToUTC('2021-06-05')).toBe('2021-06-05T07:00:00.000Z')
+    expect(convertDateToUTC('2021-06-12', true)).toBe('2021-06-13T06:59:59.999Z')
   })
 })

--- a/src/utils/convertDateToUTC.ts
+++ b/src/utils/convertDateToUTC.ts
@@ -1,11 +1,13 @@
+import { parseLocalDate } from './localDate'
+
 export function convertDateToUTC(dateString: string, endOfDay = false): string {
   if (!dateString) return ''
 
-  const [year, month, day] = dateString.split('T')[0].split('-').map(Number)
+  const date = parseLocalDate(dateString)
 
   const utcDate = endOfDay
-    ? new Date(Date.UTC(year, month - 1, day, 23, 59, 59, 999))
-    : new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0))
+    ? new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999)
+    : date
 
   return utcDate.toISOString()
 }

--- a/src/utils/localDate.ts
+++ b/src/utils/localDate.ts
@@ -1,0 +1,10 @@
+export function parseLocalDate(dateString: string) {
+  return new Date(`${dateString.split('T')[0]}T00:00:00`)
+}
+
+export function formatLocalDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,10 @@ export default defineConfig({
           environment: 'jsdom',
           setupFiles: './setup-tests.ts',
           include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
-          exclude: ['src/utils/__tests__/convertDateToUTC.test.ts'],
+          exclude: [
+            'src/utils/__tests__/convertDateToUTC.test.ts',
+            'src/**/__tests__/*.tz.test.{ts,tsx}',
+          ],
         },
       },
       {
@@ -38,7 +41,10 @@ export default defineConfig({
           globals: true,
           environment: 'jsdom',
           setupFiles: './setup-tests.ts',
-          include: ['src/utils/__tests__/convertDateToUTC.test.ts'],
+          include: [
+            'src/utils/__tests__/convertDateToUTC.test.ts',
+            'src/components/__tests__/DateInput.tz.test.tsx',
+          ],
           env: { TZ: 'America/Los_Angeles' },
         },
       },


### PR DESCRIPTION
**Timezone-safe date parsing**
- Replaced bare `new Date(value)` calls with `parseLocalDate()` which constructs a local-timezone midnight date instead of UTC midnight, preventing the displayed day from shifting in non-UTC timezones

**`convertDateToUTC` semantic fix**
- Changed the function to treat input dates as local calendar dates rather than UTC dates, so the computed UTC range (e.g. for leaderboard queries) actually spans the user's local day regardless of timezone offset or DST

**API date serialisation simplification**
- Removed `convertDateToUTC` from `useStats` query params; the backend already expects plain `yyyy-mm-dd` strings, and the values are now in local time, so the extra conversion was both unnecessary and incorrect

**Filter section alignment**
- Flipped `items-end` to `items-start` in three filter bars (EventsFiltersSection, LeaderboardEntries, StatMetrics) and added `self-end` to the EventsFilter dropdown container to fix layout with the taller date inputs