### PR TITLE
Use correct timezone in chart labels

### DIFF
--- a/src/components/charts/ChartCardTooltip.tsx
+++ b/src/components/charts/ChartCardTooltip.tsx
@@ -1,5 +1,5 @@
-import { format } from 'date-fns'
 import { ReactNode } from 'react'
+import { formatUTC } from '../../utils/formatUTC'
 
 type ChartCardTooltipProps<T> = {
   active?: boolean
@@ -18,7 +18,7 @@ export function ChartCardTooltip<T>({
 
   return (
     <div className='rounded bg-white p-4'>
-      <p className='text-sm font-medium text-black'>{format(new Date(label), 'dd MMM yyyy')}</p>
+      <p className='text-sm font-medium text-black'>{formatUTC(label, 'dd MMM yyyy')}</p>
       {formatter(payload[0].payload)}
     </div>
   )

--- a/src/components/charts/EventChartTooltip.tsx
+++ b/src/components/charts/EventChartTooltip.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx'
-import { format } from 'date-fns'
 import { uniqBy } from 'lodash-es'
 import { Fragment } from 'react'
 import { z } from 'zod'
 import { eventsVisualisationPayloadSchema } from '../../api/useEvents'
+import { formatUTC } from '../../utils/formatUTC'
 import { getPersistentColour } from '../../utils/getPersistentColour'
 
 type Payload = z.infer<typeof eventsVisualisationPayloadSchema>
@@ -25,9 +25,7 @@ export function EventChartTooltip({ active, payload, label }: ChartTooltipProps)
 
   return (
     <div className='rounded bg-white p-4'>
-      <p className='text-sm font-medium text-black'>
-        {format(new Date(label!), 'EEEE dd MMM yyyy')}
-      </p>
+      <p className='text-sm font-medium text-black'>{formatUTC(label!, 'EEEE dd MMM yyyy')}</p>
       <ul className='mt-4 grid grid-cols-[2fr_1fr_0.5fr] gap-y-2 text-black'>
         {uniqBy(filteredItems, 'payload.name')
           .sort((a, b) => b.payload.count - a.payload.count)

--- a/src/components/charts/EventsLineChart.tsx
+++ b/src/components/charts/EventsLineChart.tsx
@@ -1,8 +1,8 @@
-import { format } from 'date-fns'
 import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts'
 import { z } from 'zod'
 import { eventsVisualisationPayloadSchema } from '../../api/useEvents'
 import ChartTick from '../../components/charts/ChartTick'
+import { formatUTC } from '../../utils/formatUTC'
 import { getPersistentColour } from '../../utils/getPersistentColour'
 import { EventChartContainer } from './EventChartContainer'
 import { EventChartTooltip } from './EventChartTooltip'
@@ -38,7 +38,7 @@ export function EventsLineChart({ events, selectedEventNames }: Props) {
               transform={(x, y) => `translate(${x},${y}) rotate(-30)`}
               formatter={(tick) => {
                 if (!isFinite(tick as number)) return tick
-                return format(new Date(tick), 'd MMM')
+                return formatUTC(tick, 'd MMM')
               }}
             />
           }

--- a/src/components/charts/StatGlobalValueChart.tsx
+++ b/src/components/charts/StatGlobalValueChart.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx'
-import { format } from 'date-fns'
 import { useAtomValue } from 'jotai'
 import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts'
 import { useStatGlobalValueChart } from '../../api/useStatGlobalValueChart'
 import { activeGameState, SelectedActiveGame } from '../../state/activeGameState'
+import { formatUTC } from '../../utils/formatUTC'
 import { ChartCard } from './ChartCard'
 import { ChartCardTooltip } from './ChartCardTooltip'
 import ChartTick from './ChartTick'
@@ -45,7 +45,7 @@ export function StatGlobalValueChart({
           tick={
             <ChartTick
               transform={(x, y) => `translate(${x},${y}) rotate(-15)`}
-              formatter={(tick) => format(new Date(tick), 'd MMM')}
+              formatter={(tick) => formatUTC(tick, 'd MMM')}
             />
           }
         />

--- a/src/utils/__tests__/formatUTC.test.ts
+++ b/src/utils/__tests__/formatUTC.test.ts
@@ -1,0 +1,22 @@
+import { formatUTC } from '../formatUTC'
+
+// these run with TZ=America/Los_Angeles, see vite.config.ts
+describe('formatUTC', () => {
+  it('renders a UTC midnight bucket as that UTC day, not the local day', () => {
+    // 2026-07-12T00:00:00Z - in PDT this instant is 2026-07-11 17:00,
+    // so local-time formatting would incorrectly show "11 Jul".
+    expect(formatUTC(1783814400000, 'd MMM')).toBe('12 Jul')
+  })
+
+  it('renders a full weekday and date in UTC', () => {
+    expect(formatUTC(1783814400000, 'EEEE dd MMM yyyy')).toBe('Sunday 12 Jul 2026')
+  })
+
+  it('accepts a Date instance', () => {
+    expect(formatUTC(new Date(1783814400000), 'd MMM')).toBe('12 Jul')
+  })
+
+  it('accepts an ISO string', () => {
+    expect(formatUTC('2026-07-12T00:00:00.000Z', 'd MMM')).toBe('12 Jul')
+  })
+})

--- a/src/utils/formatUTC.ts
+++ b/src/utils/formatUTC.ts
@@ -1,0 +1,6 @@
+import { format } from 'date-fns'
+
+export function formatUTC(date: Date | number | string, formatStr: string) {
+  const d = new Date(date)
+  return format(d.getTime() + d.getTimezoneOffset() * 60000, formatStr)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
           include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
           exclude: [
             'src/utils/__tests__/convertDateToUTC.test.ts',
+            'src/utils/__tests__/formatUTC.test.ts',
             'src/**/__tests__/*.tz.test.{ts,tsx}',
           ],
         },
@@ -43,6 +44,7 @@ export default defineConfig({
           setupFiles: './setup-tests.ts',
           include: [
             'src/utils/__tests__/convertDateToUTC.test.ts',
+            'src/utils/__tests__/formatUTC.test.ts',
             'src/components/__tests__/DateInput.tz.test.tsx',
           ],
           env: { TZ: 'America/Los_Angeles' },


### PR DESCRIPTION
**UTC date formatting**

- Chart tooltips (`ChartCardTooltip`, `EventChartTooltip`, `EventsLineChart`, `StatGlobalValueChart`) were formatting timestamps with `date-fns` `format(new Date(...))`, which rendered dates in the viewer's local timezone, causing midnight-bucketed data to appear a day off in negative-offset timezones like America/Los_Angeles
- A new `formatUTC` utility was added that offsets the Date by the local timezone offset before formatting so all chart labels consistently show the UTC day regardless of the user's browser timezone

**Test infrastructure for timezone-aware tests**

- `vite.config.ts` was updated to run the new `formatUTC.test.ts` (and the existing `convertDateToUTC.test.ts` and `DateInput.tz.test.tsx`) in a dedicated Vitest pool with `TZ=America/Los_Angeles` to verify the fix behaves correctly in a negative-offset timezone, while all other tests continue to run in UTC as before