### PR TITLE
Merge duplicate prop keys into a single badge

### DIFF
--- a/src/components/PropBadges.tsx
+++ b/src/components/PropBadges.tsx
@@ -29,12 +29,27 @@ export function PropBadges({
   contentRenderer = defaultContentRenderer,
 }: Props) {
   const sortedProps = useMemo(() => {
-    return props.filter((prop) => !isMetaProp(prop)).sort((a, b) => a.key.localeCompare(b.key))
+    const grouped = new Map<string, Prop[]>()
+
+    props
+      .filter((prop) => !isMetaProp(prop))
+      .forEach((prop) => {
+        grouped.set(prop.key, [...(grouped.get(prop.key) ?? []), prop])
+      })
+
+    return [...grouped.entries()]
+      .map(([key, entries]) => ({
+        key,
+        value: entries.map((entry) => entry.value).join(', '),
+        firstValue: entries[0].value,
+      }))
+      .filter((prop) => prop.key !== '')
+      .sort((a, b) => a.key.localeCompare(b.key))
   }, [props])
 
   return (
     <div className={clsx('gap-2', className)}>
-      {sortedProps.map(({ key, value }) => (
+      {sortedProps.map(({ key, value, firstValue }) => (
         <span key={`${key}-${value}`} className='flex w-fit rounded bg-gray-900 text-xs'>
           <code className='inline-block p-2 align-middle break-all'>
             {contentRenderer({ key, value })}
@@ -46,7 +61,7 @@ export function PropBadges({
                 className={clsx('grow rounded-r bg-indigo-900 px-2', focusStyle, {
                   'bg-orange-900': devBuild,
                 })}
-                onClick={() => onClick({ key, value })}
+                onClick={() => onClick({ key, value: firstValue })}
                 aria-label={buttonTitle}
               >
                 {Icon}

--- a/src/components/__tests__/PropBadges.test.tsx
+++ b/src/components/__tests__/PropBadges.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PropBadges } from '../PropBadges'
+
+describe('<PropBadges />', () => {
+  it('should render a single badge per unique key', () => {
+    render(
+      <PropBadges
+        props={[
+          { key: 'b', value: '2' },
+          { key: 'a', value: '1' },
+        ]}
+      />,
+    )
+
+    const badges = screen.getAllByText(/=/)
+    expect(badges).toHaveLength(2)
+    expect(badges[0]).toHaveTextContent('a = 1')
+    expect(badges[1]).toHaveTextContent('b = 2')
+  })
+
+  it('should pass the first value to onClick for a merged badge', async () => {
+    const onClick = vi.fn()
+    render(
+      <PropBadges
+        props={[
+          { key: 'weapons[]', value: 'sword' },
+          { key: 'weapons[]', value: 'axe' },
+        ]}
+        onClick={onClick}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(onClick).toHaveBeenCalledWith({ key: 'weapons[]', value: 'sword' })
+  })
+
+  it('should merge props with the same key suffixed with [] into one array badge', () => {
+    render(
+      <PropBadges
+        props={[
+          { key: 'weapons[]', value: 'sword' },
+          { key: 'weapons[]', value: 'axe' },
+          { key: 'weapons[]', value: 'bow' },
+        ]}
+      />,
+    )
+
+    const badges = screen.getAllByText(/=/)
+    expect(badges).toHaveLength(1)
+    expect(badges[0]).toHaveTextContent('weapons[] = sword, axe, bow')
+  })
+
+  it('should keep a non-array key separate from an array key', () => {
+    render(
+      <PropBadges
+        props={[
+          { key: 'mainhand', value: 'sword' },
+          { key: 'weapons[]', value: 'axe' },
+          { key: 'weapons[]', value: 'bow' },
+        ]}
+      />,
+    )
+
+    const badges = screen.getAllByText(/=/)
+    expect(badges).toHaveLength(2)
+    expect(badges[0]).toHaveTextContent('mainhand = sword')
+    expect(badges[1]).toHaveTextContent('weapons[] = axe, bow')
+  })
+})


### PR DESCRIPTION
**Merged duplicate prop badges**
- Props that repeat the same key now render as a single badge instead of several, with values joined into a comma-separated list.
- Clicking a merged badge passes the first value for that key, so row selection stays deterministic.
- Props with distinct keys still get one badge each, and empty keys are excluded.

**Array-style keys**
- Repeated keys such as `weapons[]` now collapse into one array badge (e.g. `weapons[] = sword, axe, bow`) instead of one badge per entry.